### PR TITLE
Simulating unbalanced classes

### DIFF
--- a/pipeline_sandbox.ipynb
+++ b/pipeline_sandbox.ipynb
@@ -40,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Import the `proclam.Simulator` superclass and the simulator subclass you want to test.  In this notebook, I'm going to use a uniform distribution of true classes."
+    "Import the `proclam.Simulator` superclass and the simulator subclass you want to test.  In this notebook, I'm going to use an unbalanced distribution of true classes such that the probability of an object being in class $m$ (with $0 \\leq m \\leq M$) is proportional to $10^{y}$, where $y$ is a draw from a uniform distribution $U(0,M)$."
    ]
   },
   {
@@ -68,8 +68,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = proclam.simulators.unbalanced.Unbalanced()\n",
+    "A = proclam.simulators.unbalanced.LogUnbalanced()\n",
     "truth = A.simulate(3, 1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can check that the class distribution is as expected with a histogram of the true classes."
    ]
   },
   {

--- a/pipeline_sandbox.ipynb
+++ b/pipeline_sandbox.ipynb
@@ -11,7 +11,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,12 +45,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "from proclam.simulators import simulator\n",
-    "from proclam.simulators import uniform"
+    "from proclam.simulators import unbalanced"
    ]
   },
   {
@@ -54,13 +64,37 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "choice() got an unexpected keyword argument 'seed'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-4-e2b03a625944>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mA\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mproclam\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulators\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0munbalanced\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mUnbalanced\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mtruth\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mA\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1000\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/home/aimalz/Code/proclam/proclam/simulators/unbalanced.py\u001b[0m in \u001b[0;36msimulate\u001b[0;34m(self, M, N)\u001b[0m\n\u001b[1;32m     50\u001b[0m         \u001b[0mcounts\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m10\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mflip\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mM\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     51\u001b[0m         \u001b[0mprob_classes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcounts\u001b[0m\u001b[0;34m/\u001b[0m\u001b[0mfloat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msum\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcounts\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 52\u001b[0;31m         \u001b[0mtruth\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrandom\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mchoice\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mM\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msize\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mN\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mp\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mprob_classes\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mseed\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mseed\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     53\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     54\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mtruth\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32mmtrand.pyx\u001b[0m in \u001b[0;36mmtrand.RandomState.choice\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: choice() got an unexpected keyword argument 'seed'"
+     ]
+    }
+   ],
+   "source": [
+    "A = proclam.simulators.unbalanced.Unbalanced()\n",
+    "truth = A.simulate(3, 1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = proclam.simulators.uniform.Uniform()\n",
-    "truth = A.simulate(3, 100)\n",
-    "# print truth"
+    "plt.hist(truth, log=True)\n",
+    "plt.ylabel('counts')\n",
+    "plt.xlabel('class number')"
    ]
   },
   {
@@ -104,7 +138,7 @@
    "source": [
     "B = proclam.classifiers.guess.Guess()\n",
     "prediction = B.classify(3, truth, other=False)\n",
-    "# print(prediction)"
+    "print(prediction)"
    ]
   },
   {

--- a/pipeline_sandbox.ipynb
+++ b/pipeline_sandbox.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,23 +64,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "choice() got an unexpected keyword argument 'seed'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-4-e2b03a625944>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mA\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mproclam\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulators\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0munbalanced\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mUnbalanced\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mtruth\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mA\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1000\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/home/aimalz/Code/proclam/proclam/simulators/unbalanced.py\u001b[0m in \u001b[0;36msimulate\u001b[0;34m(self, M, N)\u001b[0m\n\u001b[1;32m     50\u001b[0m         \u001b[0mcounts\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m10\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mflip\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mM\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     51\u001b[0m         \u001b[0mprob_classes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcounts\u001b[0m\u001b[0;34m/\u001b[0m\u001b[0mfloat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msum\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcounts\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 52\u001b[0;31m         \u001b[0mtruth\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrandom\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mchoice\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mM\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msize\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mN\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mp\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mprob_classes\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mseed\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mseed\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     53\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     54\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mtruth\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32mmtrand.pyx\u001b[0m in \u001b[0;36mmtrand.RandomState.choice\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: choice() got an unexpected keyword argument 'seed'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "A = proclam.simulators.unbalanced.Unbalanced()\n",
     "truth = A.simulate(3, 1000)"

--- a/proclam/simulators/__init__.py
+++ b/proclam/simulators/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from . import simulator
 from . import uniform
-from . import unbalanced
+from . import logunbalanced

--- a/proclam/simulators/__init__.py
+++ b/proclam/simulators/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import
 from . import simulator
 from . import uniform
+from . import unbalanced

--- a/proclam/simulators/logunbalanced.py
+++ b/proclam/simulators/logunbalanced.py
@@ -42,7 +42,7 @@ class LogUnbalanced(Simulator):
         """
 
         counts = 10 ** (np.sort(np.random.uniform(M, size=M)))
-        prob_classes = counts / float(np.sum(counts))
+        prob_classes = counts / np.sum(counts)
         truth = np.random.choice(M, size=N, p=prob_classes)
 
         return truth

--- a/proclam/simulators/logunbalanced.py
+++ b/proclam/simulators/logunbalanced.py
@@ -1,5 +1,5 @@
 """
-A subclass for an unbalanced distribution of classes.
+A subclass for a log-scaled unbalanced distribution of classes.
 """
 
 from __future__ import absolute_import
@@ -7,11 +7,11 @@ import numpy as np
 
 from .simulator import Simulator
 
-class Unbalanced(Simulator):
+class LogUnbalanced(Simulator):
 
-    def __init__(self, scheme='unbalanced', seed=0):
+    def __init__(self, scheme='log-unbalanced', seed=0):
         """
-        An object that simulates umbalanced true class assignments such that the probability of an object being on class 'x' (with 0<=x<=M) is proportional to 10**y, where y is a draw from a uniform distribution U(0,M).
+        An object that simulates umbalanced true class assignments such that the probability of an object being in class 'x' (with 0<=x<=M) is proportional to 10**y, where y is a draw from a uniform distribution U(0,M).
 
         Parameters
         ----------
@@ -21,7 +21,7 @@ class Unbalanced(Simulator):
             the random seed to use, handy for testing
         """
 
-        super(Unbalanced, self).__init__(scheme, seed)
+        super(LogUnbalanced, self).__init__(scheme, seed)
         np.random.seed(seed=self.seed)
 
     def simulate(self, M, N):
@@ -41,7 +41,7 @@ class Unbalanced(Simulator):
             array of true class indices
         """
 
-        counts = 10 ** (np.flip(np.arange(M), axis=0))
+        counts = 10 ** (np.sort(np.random.uniform(M, size=M)))
         prob_classes = counts / float(np.sum(counts))
         truth = np.random.choice(M, size=N, p=prob_classes)
 

--- a/proclam/simulators/unbalanced.py
+++ b/proclam/simulators/unbalanced.py
@@ -1,6 +1,7 @@
 """
-A subclass for a unbalanced distribution of classes.
+A subclass for an unbalanced distribution of classes.
 """
+
 from __future__ import absolute_import
 import numpy as np
 
@@ -39,11 +40,15 @@ class Unbalanced(Simulator):
         truth: numpy.ndarray, int
             array of true class indices
         """
+        #
+        # counts = 10**(np.arange(N))
+        # prob_classes = counts/np.sum(counts)
+        #
+        #
+        # truth = np.random.choice(M, size=N, p=prob_classes)
 
-        counts = 10**(np.random.uniform(M,size=M))
-        prob_classes = counts/np.sum(counts)
-        
-
+        counts = 10**(np.flip(np.arange(M), axis=0))
+        prob_classes = counts/float(np.sum(counts))
         truth = np.random.choice(M, size=N, p=prob_classes)
 
         return truth

--- a/proclam/simulators/unbalanced.py
+++ b/proclam/simulators/unbalanced.py
@@ -41,8 +41,8 @@ class Unbalanced(Simulator):
             array of true class indices
         """
 
-        counts = 10**(np.flip(np.arange(M), axis=0))
-        prob_classes = counts/float(np.sum(counts))
+        counts = 10 ** (np.flip(np.arange(M), axis=0))
+        prob_classes = counts / float(np.sum(counts))
         truth = np.random.choice(M, size=N, p=prob_classes)
 
         return truth

--- a/proclam/simulators/unbalanced.py
+++ b/proclam/simulators/unbalanced.py
@@ -40,12 +40,6 @@ class Unbalanced(Simulator):
         truth: numpy.ndarray, int
             array of true class indices
         """
-        #
-        # counts = 10**(np.arange(N))
-        # prob_classes = counts/np.sum(counts)
-        #
-        #
-        # truth = np.random.choice(M, size=N, p=prob_classes)
 
         counts = 10**(np.flip(np.arange(M), axis=0))
         prob_classes = counts/float(np.sum(counts))


### PR DESCRIPTION
The `LogUnbalanced` simulator of unbalanced classes produces class assignments following a log-scaling starting from uniformly random exponents.  I renamed it to be a little more specific and added a histogram to the pipeline notebook so we can check that our truth is distributed as intended.  @juramaga Please review the PR, and then I'll merge `rafmetric-patch` into the `rafmetric` branch and then into the `master` branch.  Since this is the only scenario the simulation team requested, we can close #8 when this is done.  Thanks again @juramaga!